### PR TITLE
fix: correct return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare const branchName: (options?: {
   cwd?: string;
   branchOptions?: string | string[];
-}) => boolean;
+}) => string | false;
 export default branchName;


### PR DESCRIPTION
Per the documentation, the library either returns the current branch name or false.